### PR TITLE
Add a safeWrite method that skips invalid tags

### DIFF
--- a/src/main/java/se/llbit/nbt/CompoundTag.java
+++ b/src/main/java/se/llbit/nbt/CompoundTag.java
@@ -70,6 +70,13 @@ public class CompoundTag extends SpecificTag implements Iterable<NamedTag> {
     out.writeByte(Tag.TAG_END);
   }
 
+  @Override public void safeWrite(DataOutputStream out) throws IOException {
+    for (NamedTag tag : items.values()) {
+      tag.safeWrite(out);
+    }
+    out.writeByte(Tag.TAG_END);
+  }
+
   static Map<String, Tag> partialParse(DataInputStream in, String prefix,
       Map<String, Tag> result, Set<String> request, Set<String> prefixes) {
     try {

--- a/src/main/java/se/llbit/nbt/ErrorTag.java
+++ b/src/main/java/se/llbit/nbt/ErrorTag.java
@@ -38,6 +38,10 @@ public class ErrorTag extends SpecificTag {
     throw new RuntimeException("Cannot write an error tag to NBT stream (" + getError() + ")");
   }
 
+  @Override public void safeWrite(DataOutputStream out) {
+    // do nothing (this tag represents an invalid tag)
+  }
+
   public ErrorTag(String message) {
     this.message = message;
   }

--- a/src/main/java/se/llbit/nbt/ListTag.java
+++ b/src/main/java/se/llbit/nbt/ListTag.java
@@ -72,6 +72,22 @@ public class ListTag extends SpecificTag implements Iterable<SpecificTag> {
     }
   }
 
+  @Override public void safeWrite(DataOutputStream out) throws IOException {
+    out.writeByte(getType());
+
+    List<SpecificTag> validTags = new ArrayList<>();
+    for (SpecificTag item : items) {
+      if (!(item instanceof ErrorTag)) {
+        validTags.add(item);
+      }
+    }
+
+    out.writeInt(validTags.size());
+    for (SpecificTag item : validTags) {
+      item.safeWrite(out);
+    }
+  }
+
   static Map<String, Tag> partialParse(DataInputStream in, String prefix,
       Map<String, Tag> result, Set<String> request, Set<String> prefixes) {
 

--- a/src/main/java/se/llbit/nbt/NamedTag.java
+++ b/src/main/java/se/llbit/nbt/NamedTag.java
@@ -70,6 +70,14 @@ public class NamedTag extends Tag {
     getTag().write(out);
   }
 
+  @Override public void safeWrite(DataOutputStream out) throws IOException {
+    if (!(tag instanceof ErrorTag)) {
+      getTag().writeType(out);
+      StringTag.write(out, name);
+      getTag().safeWrite(out);
+    }
+  }
+
   /**
    * Parse only the requested tags.
    *

--- a/src/main/java/se/llbit/nbt/Tag.java
+++ b/src/main/java/se/llbit/nbt/Tag.java
@@ -132,7 +132,23 @@ public abstract class Tag {
     return "";
   }
 
+  /**
+   * Write this tag to the given output stream. If this tag or a child tag (e.g. in a
+   * compound tag) is invalid, an error is thrown.
+   * @param out output stream to write the valid tags to
+   * @throws IOException
+   */
   public abstract void write(DataOutputStream out) throws IOException;
+
+  /**
+   * Write this tag to the given output stream, if it is a valid tag. Invalid child tags (e.g. in a
+   * compound tag) are also skipped.
+   * @param out output stream to write the valid tags to
+   * @throws IOException
+   */
+  public void safeWrite(DataOutputStream out) throws IOException {
+    write(out);
+  }
 
   public String toString() {
     return tagName() + extraInfo();


### PR DESCRIPTION
Chunky uses NBT tag serialization to store scene data. If there are broken tags in the loaded chunks, that doesn't cause errors while loading or using them (as long as the invalid nbt tags aren't read). When saving the NBT data (which Chunky does when saving the block palette), saving invalid NBT data fails.

In the case of Chunky, it would be preferable to just skip invalid NBT data, because a scene that can be loaded and rendered should also be saved. That's why this PR adds a `safeWrite` method that skips invalid NBT data during serialization.